### PR TITLE
Update ruby 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.4.3
+  - 2.4.4
 
 sudo: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.4.3'
+ruby '2.4.4'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")


### PR DESCRIPTION
docker-compose up fails.

```sh
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and                                                                                    
installing your bundle as root will break this application for all non-root                                                  
users on this machine.                                                                                                                                 
Your Ruby version is 2.4.4, but your Gemfile specified 2.4.3
ERROR: Service 'app' failed to build: The command '/bin/sh -c apk add --update --virtual build-dependencies --no-cache $DEV_PACKAGES &&     gem install bundler --no-document &&     bundle config build.
nokogiri --use-system-libraries &&     bundle install --without development test heroku &&     apk del build-dependencies' returned a non-zero code: 18
```

This is because the version of Alpine's ruby ​​package has reached 2.4.4.
https://pkgs.alpinelinux.org/packages?name=ruby&branch=v3.7